### PR TITLE
Fix rendering on Wayland with Nvidia

### DIFF
--- a/com.todoist.Todoist.yaml
+++ b/com.todoist.Todoist.yaml
@@ -32,7 +32,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -D apply_extra "${FLATPAK_DEST}/bin/apply_extra"
-      - install todoist "${FLATPAK_DEST}/bin/"
+      - install todoist.sh "${FLATPAK_DEST}/bin/todoist"
     post-install:
       - install -p -Dm644 "icon.png" "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png"
       - install -Dm644 todoist.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
@@ -57,10 +57,8 @@ modules:
           # TODO: This moves in a lot of junk too
           - mv squashfs-root todoist
           - touch todoist/chrome-sandbox && chmod +x todoist/chrome-sandbox
-      - type: script
-        dest-filename: todoist
-        commands:
-          - TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/todoist/todoist "$@"
+      - type: file
+        path: todoist.sh
       - type: file
         path: com.todoist.Todoist.metainfo.xml
       - type: file

--- a/todoist.sh
+++ b/todoist.sh
@@ -7,4 +7,4 @@ then
     FLAGS="$FLAGS --disable-gpu-sandbox"
 fi
 
-env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-com.todoist.Todoist}" zypak-wrapper /app/extra/todoist/todoist $FLAGS "$@"
+env TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID" zypak-wrapper /app/extra/todoist/todoist $FLAGS "$@"

--- a/todoist.sh
+++ b/todoist.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+FLAGS=''
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
+then
+    FLAGS="$FLAGS --disable-gpu-sandbox"
+fi
+
+env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-com.todoist.Todoist}" zypak-wrapper /app/extra/todoist/todoist $FLAGS "$@"


### PR DESCRIPTION
The app would not launch on Wayland with Nvidia graphics cards without --disable-gpu-sandbox. This fix enables that only for Nvidia cards on Wayland. In addition, it moves some TMP files to an app-specific folder.

This is the [same](https://github.com/flathub/im.riot.Riot/pull/239/commits/2b9214a466669c8a84cbfc7b87ecff2f1cfe8db4) as what Element does and similar to [Discord](https://github.com/flathub/com.discordapp.Discord/blob/master/discord.sh)