### PR TITLE
Use the lzo module from the runtime

### DIFF
--- a/com.todoist.Todoist.yaml
+++ b/com.todoist.Todoist.yaml
@@ -18,7 +18,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
 modules:
-  - shared-modules/lzo/lzo.json
   - shared-modules/squashfs-tools/squashfs-tools.json
 
   - name: todoist


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides the lzo module. In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/com.todoist.Todoist/issues/149